### PR TITLE
Fix default branch name in workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - primary
 
 jobs:
   unitTest:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test team-rotation
+name: Test
 
 on:
   pull_request:


### PR DESCRIPTION
The default branch name is `primary` now.